### PR TITLE
Added flexibility to upstream

### DIFF
--- a/boilerplate/upstreams/nginx.boilerplate.conf
+++ b/boilerplate/upstreams/nginx.boilerplate.conf
@@ -1,7 +1,8 @@
 upstream nginx.boilerplate
 {
+    server      unix:/var/run/php5-fpm.sock;
     server      127.0.0.1:9000 max_fails=3 fail_timeout=3s;
-    server      server unix:/var/run/php5-fpm.sock;
+    server      php.nginx.boilerplate:9000 max_fails=3 fail_timeout=3s;
     #ip_hash;
     #keepalive  16;
 }

--- a/boilerplate/upstreams/nginx.boilerplate.conf
+++ b/boilerplate/upstreams/nginx.boilerplate.conf
@@ -1,6 +1,7 @@
 upstream nginx.boilerplate
 {
-    server      php.nginx.boilerplate:9000 max_fails=3 fail_timeout=3s;
+    server      127.0.0.1:9000 max_fails=3 fail_timeout=3s;
+    server      server unix:/var/run/php5-fpm.sock;
     #ip_hash;
     #keepalive  16;
 }


### PR DESCRIPTION
Set upstream to localhost, doesn't need to be based on servername. 
Added flexibility for those who use socket (default behaviour in mostly distros)
Ref: http://nginx.org/en/docs/http/ngx_http_upstream_module.html