### PR TITLE
Create letsencrypt.conf

### DIFF
--- a/boilerplate/locations/letsencrypt.conf
+++ b/boilerplate/locations/letsencrypt.conf
@@ -1,0 +1,4 @@
+#Allow domains to be validated by ACME protocol (letsencrypt)
+location ^~ /.well-known/acme-challenge/ {
+  allow all;
+}


### PR DESCRIPTION
Allow domain to be validated by ACME protocol (https://letsencrypt.org/)